### PR TITLE
feat(gh-pages): folder layout to set Github Pages to docs/

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,43 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [INSERT EMAIL ADDRESS]. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org/), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,3 +1,3 @@
-# Contributing to node-package-blueprint
+# Contributing to the project
 
 The following is a set of guidelines for contributing to this repository on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,9 @@
+Do you want to request a feature or report a bug?
+
+What is the current behavior?
+
+If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem via [https://codesandbox.io](https://codesandbox.io/s/new).
+
+What is the expected behavior?
+
+Which versions of this project, and which browser / OS are affected by this issue? Did this work in previous versions of this project?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**Before submitting a pull request,** please make sure the following is done:
+
+1. Fork [the repository](https://github.com/researchgate/node-package-blueprint) and create your branch from `master`.
+2. If you've added code that should be tested, add tests!
+3. If you've changed APIs, update the documentation.
+4. Ensure the test suite passes (`npm test`).
+5. Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).
+6. Make sure your code lints (`npm run lint`).
+7. Run the [Flow](https://flowtype.org/) typechecks (`npm run flow`).
+8. If you haven't already, complete the CLA.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,3 @@
+# Contributing to node-package-blueprint
+
+The following is a set of guidelines for contributing to this repository on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Node Package Blueprint
+
+This folder can be the right place to *read* the documentation if that's enough.
+
+It can also be used to host files used to generate a project website, e.g. using Jekyll or other static generation tool.
+
+If this folder contains the source code for the website. Choose a folder where the source would be generated and we can make it point to custom domain, e.g.: https://researchgate.github.io/node-package-blueprint/


### PR DESCRIPTION
### Docs and Github pages
Digging into the [showcases for github pages](https://github.com/showcases/github-pages-examples), I found the docs of React to be what would IMO most adjust to our needs for OS projects.

#### Considerations
- `docs/` will contain static files
- Github previews `README.md` files under each subfolder directly
- `docs/` can contain storybook stories and code, co-location is important
   - `code|examples|.md` and other related files live under the same (sub)folders, so navigation within Github is easy
- storybook allows custom `webpack` config, should then be able to load `README.md` files and any other text/code source under any subfolder to generate examples
   - generated code from storybook could live under something like `docs/examples/`
   - if then we use Storybook we can export it [as a static app](https://storybook.js.org/basics/exporting-storybook/)
- Github pages can be accessed setting up a custom domain, e.g.: `open-source.researchgate.net/projects/project-name`

#### TODOs:
- [x] change settings to point to docs/ for github pages
- [x] figure out the contents within the folder `.github/`
- [x] figure out co-location under `docs/` of MD files + code + storybook examples

#### Example of co-located source and READMEs
https://researchgate.github.io/react-intersection-observer/?selectedKind=Examples&selectedStory=Window&full=0&down=1&left=1&panelRight=1&downPanel=tuchk4%2Freadme%2Fpanel